### PR TITLE
웹뷰에서 요청이 안되는 에러 픽스

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,16 +12,19 @@ const styles = StyleSheet.create({
 
 export default function App() {
   return (
-    <WebView
-      style={styles.WebViewStyle}
-      injectedJavaScriptBeforeContentLoaded={`
+    <>
+      <WebView
+        mixedContentMode='always'
+        style={styles.WebViewStyle}
+        injectedJavaScriptBeforeContentLoaded={`
         window.onerror = function(message, sourcefile, lineno, colno, error) {
           alert("Message: " + message + " - Source: " + sourcefile + " Line: " + lineno + ":" + colno);
           return true;
         };
       `}
-      source={{ uri: 'https://teamproject-auxios.netlify.app' }}
-    />
+        source={{ uri: 'https://teamproject-auxios.netlify.app/login' }}
+      />
+    </>
   );
 }
 

--- a/app.json
+++ b/app.json
@@ -4,30 +4,23 @@
     "slug": "auxious",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "splash": {
-      "image": "./assets/splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
-        "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
       }
     },
-    "web": {
-      "favicon": "./assets/favicon.png"
-    }
+    "web": {}
   }
 }


### PR DESCRIPTION
## 개요

Http 이미지를 요청하면 거절당하는 에러를 고쳤습니다.
[Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)
Https 와 Http 사이 정보를 요청할때 이를 거부하는 에러입니다

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

RN의 설정을 바꿔서 해결했습니다.
보안설정이 취약해진것이 단점입니다.

```js
mixedContentMode='always'
```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

mixedcontent 를 항상 허용하기 때문에 보안 취약점이 있습니다.